### PR TITLE
Fix for building standalone jar with included libs and fix for run-mapper.sh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,19 +132,30 @@
         </configuration>
       </plugin>
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-assembly-plugin</artifactId>
-	<version>2.4</version>
-	<configuration>
-	  <appendAssemblyId>false</appendAssemblyId>
-	  <descriptors>
-	    <descriptor>package.xml</descriptor>
-	  </descriptors>
-	</configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <descriptorRefs>
+          <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <archive>
+            <manifest>
+              <mainClass>nl.mpi.mdmapper.Main</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>				
       </plugin>
     </plugins>
   </build>
-
   <reporting>
     <plugins>
       <plugin>

--- a/src/main/scripts/run-mapper.sh
+++ b/src/main/scripts/run-mapper.sh
@@ -9,4 +9,4 @@ for x in lib/*.jar ; do
   y=${y}:${x}
 done
 
-nice java -cp ${y} -jar ${JAR} mapper_version=${mapper_version} $*
+nice java -cp ${y}:${JAR} nl.mpi.mdmapper.Main mapper_version=${mapper_version} $*


### PR DESCRIPTION
The fix for `run-mapper.sh` skips the use of the -jar argument and gives the main class as an argument instead. When -jar is used -cp is ignored:
http://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html#jar
`When you use this option, the JAR file is the source of all user classes, and other user class path settings are ignored.`

The change in `pom.xml` adds a second jar file for the target where all the libraries are included.
This makes the application easier to run without the need of `run-mapper.sh`
